### PR TITLE
Add caching mechanism for GitHub API responses

### DIFF
--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -1,0 +1,53 @@
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+  expiresAt: number;
+}
+
+export class Cache {
+  private static instance: Cache;
+  private storage: Map<string, CacheEntry<unknown>>;
+  private defaultTTL: number;
+
+  private constructor(defaultTTL = 5 * 60 * 1000) { // 5 minutes default TTL
+    this.storage = new Map();
+    this.defaultTTL = defaultTTL;
+  }
+
+  static getInstance(): Cache {
+    if (!Cache.instance) {
+      Cache.instance = new Cache();
+    }
+    return Cache.instance;
+  }
+
+  set<T>(key: string, value: T, ttl = this.defaultTTL): void {
+    const now = Date.now();
+    this.storage.set(key, {
+      data: value,
+      timestamp: now,
+      expiresAt: now + ttl
+    });
+  }
+
+  get<T>(key: string): T | null {
+    const entry = this.storage.get(key) as CacheEntry<T> | undefined;
+    if (!entry) return null;
+
+    const now = Date.now();
+    if (now > entry.expiresAt) {
+      this.storage.delete(key);
+      return null;
+    }
+
+    return entry.data;
+  }
+
+  clear(): void {
+    this.storage.clear();
+  }
+
+  delete(key: string): void {
+    this.storage.delete(key);
+  }
+}


### PR DESCRIPTION
This PR adds a caching mechanism for GitHub API responses to improve performance and reduce API calls. Changes include:

- Created a new `Cache` class with TTL support
- Added caching for individual API responses
- Added caching for processed bot activities
- Set default TTL to 5 minutes
- Used memory-based storage with Map

This will help reduce API rate limits and improve application performance by serving cached data when available.