### PR TITLE
Update Vercel build to generate cache

### DIFF
--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build:all",
+  "devCommand": "npm run dev",
+  "installCommand": "npm install"
+}


### PR DESCRIPTION
This PR updates the Vercel build configuration to ensure the cache is generated during each build by:

1. Setting the build command to `npm run build:all`
2. This ensures that `npm run build:cache` is executed before the frontend build

Note: Make sure to set the `GITHUB_TOKEN` environment variable in your Vercel project settings with the required scopes (`repo` and `read:org` if needed).