### PR TITLE
Fix cache generation script to use cache-github-data.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build --mode production",
-    "build:cache": "echo 'Building cache...' && cd scripts && echo 'Installing dependencies...' && npm install && echo 'Compiling TypeScript...' && npx tsc && echo 'Generating GitHub data cache...' && node dist/github-api.js && echo 'Cache generation complete'",
+    "build:cache": "echo 'Building cache...' && cd scripts && echo 'Installing dependencies...' && npm install && echo 'Compiling TypeScript...' && npx tsc && echo 'Generating GitHub data cache...' && node dist/cache-github-data.js && echo 'Cache generation complete'",
     "build:all": "npm run build:cache && npm run build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
The vega-lite plots were not showing success activities and PR activities because the cache generation script was running github-api.js directly instead of cache-github-data.js. This PR fixes that issue.