### PR TITLE
Add dependabot workflow and update cache duration

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/scripts/src/github-api.ts
+++ b/scripts/src/github-api.ts
@@ -206,10 +206,10 @@ export async function fetchBotActivities(since?: string): Promise<Activity[]> {
     if (since !== undefined && since !== '') {
       params.append('since', since);
     } else {
-      // Default to last 7 days if no since parameter
-      const sevenDaysAgo = new Date();
-      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-      params.append('since', sevenDaysAgo.toISOString());
+      // Default to last 30 days if no since parameter
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+      params.append('since', thirtyDaysAgo.toISOString());
     }
 
     // Fetch issues and PRs


### PR DESCRIPTION
This PR includes:

1. Added a new workflow file for dependabot that will automatically merge patch and minor version updates
2. Changed the cache duration from 7 days to 30 days in the GitHub API fetch function