### PR TITLE
fix: Remove direct GitHub API calls from frontend

### DIFF
--- a/src/services/github.test.ts
+++ b/src/services/github.test.ts
@@ -39,18 +39,13 @@ describe('GitHub Service', () => {
           activities: [{
             id: 'issue-1-2',
             type: 'issue',
-            status: 'success',
+            status: 'pr_open',
             timestamp: '2023-11-28T00:01:00Z',
             url: 'https://github.com/All-Hands-AI/OpenHands/issues/1#comment-2',
             prUrl: 'https://api.github.com/repos/All-Hands-AI/OpenHands/pulls/2',
             description: 'A potential fix has been generated and a draft PR #2 has been created. Please review the changes.'
           }],
           lastUpdated: '2023-11-28T00:01:00Z'
-        });
-      } else if (url === 'https://api.github.com/repos/All-Hands-AI/OpenHands/pulls/2') {
-        return createMockResponse({
-          state: 'open',
-          merged: false
         });
       }
       throw new Error(`Unexpected URL: ${url}`);
@@ -78,7 +73,7 @@ describe('GitHub Service', () => {
           activities: [{
             id: 'issue-1-2',
             type: 'issue',
-            status: 'failure',
+            status: 'no_pr',
             timestamp: '2023-11-28T00:01:00Z',
             url: 'https://github.com/All-Hands-AI/OpenHands/issues/1#comment-2',
             description: 'The workflow to fix this issue encountered an error. Openhands failed to create any code changes.'
@@ -143,7 +138,7 @@ describe('GitHub Service', () => {
           activities: [{
             id: 'issue-1-2',
             type: 'issue',
-            status: 'success',
+            status: 'no_pr',
             timestamp: '2023-11-28T00:01:00Z',
             url: 'https://github.com/All-Hands-AI/OpenHands/issues/1#comment-2',
             description: 'Working on the issue...'
@@ -173,18 +168,13 @@ describe('GitHub Service', () => {
           activities: [{
             id: 'issue-1-2',
             type: 'issue',
-            status: 'success',
+            status: 'pr_open',
             timestamp: '2023-11-28T00:01:00Z',
             url: 'https://github.com/All-Hands-AI/OpenHands/issues/1#comment-2',
             prUrl: 'https://api.github.com/repos/All-Hands-AI/OpenHands/pulls/2',
             description: 'Created PR #2'
           }],
           lastUpdated: '2023-11-28T00:01:00Z'
-        });
-      } else if (url === 'https://api.github.com/repos/All-Hands-AI/OpenHands/pulls/2') {
-        return createMockResponse({
-          state: 'open',
-          merged: false
         });
       }
       throw new Error(`Unexpected URL: ${url}`);
@@ -209,18 +199,13 @@ describe('GitHub Service', () => {
           activities: [{
             id: 'issue-1-2',
             type: 'issue',
-            status: 'success',
+            status: 'pr_merged',
             timestamp: '2023-11-28T00:01:00Z',
             url: 'https://github.com/All-Hands-AI/OpenHands/issues/1#comment-2',
             prUrl: 'https://api.github.com/repos/All-Hands-AI/OpenHands/pulls/2',
             description: 'Created PR #2'
           }],
           lastUpdated: '2023-11-28T00:01:00Z'
-        });
-      } else if (url === 'https://api.github.com/repos/All-Hands-AI/OpenHands/pulls/2') {
-        return createMockResponse({
-          state: 'closed',
-          merged: true
         });
       }
       throw new Error(`Unexpected URL: ${url}`);
@@ -245,18 +230,13 @@ describe('GitHub Service', () => {
           activities: [{
             id: 'issue-1-2',
             type: 'issue',
-            status: 'success',
+            status: 'pr_closed',
             timestamp: '2023-11-28T00:01:00Z',
             url: 'https://github.com/All-Hands-AI/OpenHands/issues/1#comment-2',
             prUrl: 'https://api.github.com/repos/All-Hands-AI/OpenHands/pulls/2',
             description: 'Created PR #2'
           }],
           lastUpdated: '2023-11-28T00:01:00Z'
-        });
-      } else if (url === 'https://api.github.com/repos/All-Hands-AI/OpenHands/pulls/2') {
-        return createMockResponse({
-          state: 'closed',
-          merged: false
         });
       }
       throw new Error(`Unexpected URL: ${url}`);

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,4 +1,4 @@
-import { BotActivity, IssueActivityStatus } from '../types';
+import { BotActivity } from '../types';
 
 // PR status is now included in the cached data, no need to fetch it
 

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -1,25 +1,6 @@
 import { BotActivity, IssueActivityStatus } from '../types';
 
-async function checkPRStatus(prUrl: string): Promise<IssueActivityStatus> {
-  try {
-    const response = await fetch(prUrl);
-    if (!response.ok) {
-      return 'no_pr';
-    }
-    const pr = await response.json();
-    
-    if (pr.merged) {
-      return 'pr_merged';
-    } else if (pr.state === 'closed') {
-      return 'pr_closed';
-    } else {
-      return 'pr_open';
-    }
-  } catch (error) {
-    console.error('Error checking PR status:', error);
-    return 'no_pr';
-  }
-}
+// PR status is now included in the cached data, no need to fetch it
 
 export async function fetchBotActivities(since?: string): Promise<BotActivity[]> {
   try {
@@ -39,18 +20,8 @@ export async function fetchBotActivities(since?: string): Promise<BotActivity[]>
       );
     }
 
-    // Process issue activities to determine PR status
-    const processedActivities = await Promise.all(activities.map(async activity => {
-      if (activity.type === 'issue') {
-        if (activity.prUrl) {
-          const prStatus = await checkPRStatus(activity.prUrl);
-          return { ...activity, status: prStatus };
-        } else {
-          return { ...activity, status: 'no_pr' as IssueActivityStatus };
-        }
-      }
-      return activity;
-    }));
+    // PR status is already included in the cached data
+    const processedActivities = activities;
 
     // Sort by timestamp in descending order
     return processedActivities.sort((a, b) => 


### PR DESCRIPTION
Fixes #39

The frontend was making direct calls to the GitHub API to check PR status, which was causing 403 errors. This change removes those direct API calls since the PR status is already included in the cached data that is built by the backend.

Changes:
- Removed `checkPRStatus` function from frontend service
- Removed PR status fetching from `fetchBotActivities` since it is already included in the cached data

This should resolve the 403 errors since the frontend will no longer make any direct calls to the GitHub API.